### PR TITLE
increased memory allocation

### DIFF
--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -254,10 +254,10 @@ brokerReadinessProbe:
 brokerResources:
    limits:
      cpu: 1
-     memory: "256Mi"
+     memory: "1Gi"
    requests:
      cpu: 1
-     memory: "256Mi"
+     memory: "1Gi"
 
 
 ##### Container Registry Agent Resource Values #####


### PR DESCRIPTION
increased default memory allocation values in the snyk broker, 256Mi is not sufficient.